### PR TITLE
feat: add pihole chart with DNSCrypt-proxy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ helm repo update
 | Chart | Description | Version | App Version |
 |-------|-------------|---------|-------------|
 | **actual-server** | Self-hosted personal finance management with Actual Budget | Latest | 25.8.0 |
+| **pihole** | Network-wide DNS ad-blocker with DNSCrypt-proxy integration | Latest | 2025.08.0 |
 | **zero-api** | API service to integrate Actual Budget with ZeroTap mobile app | Latest | - |
 
 ## 💻 Installation Examples
@@ -39,6 +40,25 @@ helm install actual-budget homelab/actual-server \
 helm install actual-budget homelab/actual-server \
   --set persistence.enabled=true \
   --set persistence.size=10Gi
+```
+
+### Pi-hole DNS Ad-Blocker
+Deploy network-wide ad-blocking with encrypted DNS:
+
+```bash
+# Basic installation
+helm install pihole homelab/pihole
+
+# With custom domain and static IP
+helm install pihole homelab/pihole \
+  --set ingress.host=dns.yourdomain.com \
+  --set services.dns.loadBalancerIP=192.168.1.100 \
+  --set password.value=MySecurePassword
+
+# Without DNSCrypt-proxy sidecar
+helm install pihole homelab/pihole \
+  --set sidecar.dnscrypt.enabled=false \
+  --set config.dnsUpstreams="8.8.8.8,1.1.1.1"
 ```
 
 ### Zero API

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: pihole
+description: Pi-hole DNS ad-blocker chart
+type: application
+version: 0.1.0
+appVersion: "2025.08.0"
+
+maintainers:
+  - name: Barbaro Javier
+    email: barbar0jav1er@callbackhell.run

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -1,0 +1,195 @@
+# Pi-hole Helm Chart
+
+A comprehensive Helm chart for deploying Pi-hole DNS ad-blocker on Kubernetes with DNSCrypt-proxy integration.
+
+## Overview
+
+Pi-hole is a network-wide ad blocker that acts as a DNS sinkhole, protecting your network from ads and trackers. This chart includes:
+
+- Pi-hole DNS ad-blocker
+- DNSCrypt-proxy sidecar for encrypted DNS queries
+- Persistent storage for configuration and logs
+- LoadBalancer service for DNS queries
+- Web interface with ingress support
+
+## Features
+
+- **DNS Ad-Blocking**: Block ads, trackers, and malicious domains network-wide
+- **Encrypted DNS**: DNSCrypt-proxy sidecar for secure upstream DNS queries
+- **Web Interface**: Clean web dashboard for management and statistics
+- **Persistent Storage**: Configuration and query logs stored persistently
+- **High Availability**: Kubernetes-native deployment with health checks
+
+## Installation
+
+```bash
+helm install pihole ./charts/pihole
+```
+
+## Configuration
+
+### Basic Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Pi-hole Docker image repository | `pihole/pihole` |
+| `image.tag` | Pi-hole Docker image tag | `2025.08.0` |
+| `password.create` | Create admin password secret | `true` |
+| `password.value` | Admin password (change this!) | `changeme123` |
+| `password.existingSecret` | Use existing secret for password | `""` |
+| `password.existingSecretKey` | Key in existing secret | `admin-password` |
+
+### DNS Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `config.timezone` | Container timezone | `Europe/Madrid` |
+| `config.dnsUpstreams` | Upstream DNS servers | `127.0.0.1#5053` |
+| `services.dns.enabled` | Enable DNS service | `true` |
+| `services.dns.type` | DNS service type | `LoadBalancer` |
+| `services.dns.loadBalancerIP` | Static IP for DNS service | `""` |
+
+### DNSCrypt-proxy Sidecar
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `sidecar.dnscrypt.enabled` | Enable DNSCrypt-proxy sidecar | `true` |
+| `sidecar.dnscrypt.image.repository` | DNSCrypt-proxy image | `klutchell/dnscrypt-proxy` |
+| `sidecar.dnscrypt.image.tag` | DNSCrypt-proxy tag | `latest` |
+| `sidecar.dnscrypt.port` | DNSCrypt-proxy port | `5053` |
+| `sidecar.dnscrypt.config.server_names` | DNS servers to use | `['cloudflare', 'quad9']` |
+| `sidecar.dnscrypt.config.cache` | Enable DNS caching | `true` |
+| `sidecar.dnscrypt.config.cache_size` | DNS cache size | `4096` |
+
+### Web Interface & Ingress
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `services.web.enabled` | Enable web service | `true` |
+| `services.web.type` | Web service type | `ClusterIP` |
+| `services.web.port` | Web service port | `80` |
+| `ingress.enabled` | Enable ingress | `true` |
+| `ingress.className` | Ingress class name | `traefik` |
+| `ingress.host` | Ingress hostname | `pihole.local` |
+| `ingress.tls.enabled` | Enable TLS | `true` |
+| `ingress.tls.secretName` | TLS secret name | `pihole-tls` |
+
+### Persistence
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `persistence.config.enabled` | Enable config persistence | `true` |
+| `persistence.config.size` | Config storage size | `1Gi` |
+| `persistence.config.storageClass` | Config storage class | `""` |
+| `persistence.dnsmasq.enabled` | Enable dnsmasq persistence | `true` |
+| `persistence.dnsmasq.size` | Dnsmasq storage size | `500Mi` |
+| `persistence.dnsmasq.storageClass` | Dnsmasq storage class | `""` |
+
+### Resources
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `resources.requests.cpu` | CPU request | `100m` |
+| `resources.requests.memory` | Memory request | `128Mi` |
+| `resources.limits.cpu` | CPU limit | `500m` |
+| `resources.limits.memory` | Memory limit | `512Mi` |
+
+## Installation Examples
+
+### Basic Installation
+
+```bash
+helm install pihole ./charts/pihole \
+  --set password.value=MySecurePassword123
+```
+
+### Custom Domain and Static IP
+
+```bash
+helm install pihole ./charts/pihole \
+  --set ingress.host=dns.mydomain.com \
+  --set services.dns.loadBalancerIP=192.168.1.100 \
+  --set password.value=MySecurePassword123
+```
+
+### Using Existing Secret
+
+```bash
+# Create secret first
+kubectl create secret generic pihole-admin --from-literal=password=MySecurePassword123
+
+# Install with existing secret
+helm install pihole ./charts/pihole \
+  --set password.create=false \
+  --set password.existingSecret=pihole-admin \
+  --set password.existingSecretKey=password
+```
+
+### Disable DNSCrypt-proxy Sidecar
+
+```bash
+helm install pihole ./charts/pihole \
+  --set sidecar.dnscrypt.enabled=false \
+  --set config.dnsUpstreams="8.8.8.8,1.1.1.1"
+```
+
+### High Storage Configuration
+
+```bash
+helm install pihole ./charts/pihole \
+  --set persistence.config.size=5Gi \
+  --set persistence.dnsmasq.size=2Gi \
+  --set resources.limits.memory=1Gi
+```
+
+## Post-Installation
+
+1. **Access Web Interface**: Navigate to your configured ingress host or service IP
+2. **Login**: Use the password you configured
+3. **Configure DNS**: Point your devices to the Pi-hole DNS service IP
+4. **Add Blocklists**: Configure additional ad and tracker blocklists
+5. **Monitor**: Check the dashboard for blocked queries and statistics
+
+## Architecture
+
+```
+[Clients] -> [Pi-hole DNS Service] -> [Pi-hole Container] -> [DNSCrypt-proxy] -> [Upstream DNS]
+                                           |
+[Web Interface] <- [Pi-hole Ingress] <- [Pi-hole Web Service]
+```
+
+## Security Considerations
+
+- **Change Default Password**: Always change the default admin password
+- **Use TLS**: Enable TLS for the web interface
+- **Network Policies**: Consider implementing Kubernetes network policies
+- **Resource Limits**: Configure appropriate resource limits
+- **Regular Updates**: Keep Pi-hole image updated
+
+## Troubleshooting
+
+### DNS Not Working
+- Check if DNS service has an external IP: `kubectl get svc pihole-dns`
+- Verify pods are running: `kubectl get pods -l app.kubernetes.io/name=pihole`
+- Check logs: `kubectl logs -l app.kubernetes.io/name=pihole`
+
+### Web Interface Inaccessible
+- Verify ingress is configured: `kubectl get ingress`
+- Check web service: `kubectl get svc pihole-web`
+- Confirm TLS certificate: `kubectl get certificate`
+
+### DNSCrypt-proxy Issues
+- Check sidecar logs: `kubectl logs <pod-name> -c dnscrypt-proxy`
+- Verify configuration: `kubectl get configmap pihole-dnscrypt`
+
+## Requirements
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- LoadBalancer support (for DNS service)
+- Ingress controller (for web interface)
+- Persistent volume support
+
+## License
+
+This chart is open source and available under the MIT license.

--- a/charts/pihole/templates/NOTES.txt
+++ b/charts/pihole/templates/NOTES.txt
@@ -1,0 +1,49 @@
+🎉 Pi-hole has been installed successfully!
+
+📊 Release Information:
+   Name: {{ .Release.Name }}
+   Namespace: {{ .Release.Namespace }}
+
+{{- if .Values.ingress.enabled }}
+🌐 Web Interface:
+   URL: {{ if .Values.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.ingress.host }}
+   Path: /admin
+{{- else }}
+🌐 Web Interface:
+   To access the web interface, you need to enable ingress or port-forward:
+   kubectl port-forward service/{{ include "pihole.fullname" . }}-web 8080:80
+   Then visit: http://localhost:8080/admin
+{{- end }}
+
+🔑 Admin Credentials:
+{{- if .Values.password.create }}
+   Password: {{ .Values.password.value | quote }}
+{{- else }}
+   Password: (stored in secret {{ .Values.password.existingSecret }})
+{{- end }}
+
+{{- if .Values.services.dns.enabled }}
+📡 DNS Server:
+{{- if eq .Values.services.dns.type "LoadBalancer" }}
+   Get the external IP with:
+   kubectl get service {{ include "pihole.fullname" . }}-dns
+   
+   Then configure your devices/router to use that IP as DNS server.
+{{- else if eq .Values.services.dns.type "NodePort" }}
+   DNS available on NodePort. Get the port with:
+   kubectl get service {{ include "pihole.fullname" . }}-dns
+{{- else }}
+   DNS service is ClusterIP. Consider changing to LoadBalancer for external access.
+{{- end }}
+{{- end }}
+
+📋 Next Steps:
+1. Access the web interface using the URL above
+2. Login with the admin password
+3. Configure blocklists in Settings > Blocklists  
+4. Set Pi-hole as your DNS server
+
+🔍 Troubleshooting:
+   View pods:     kubectl get pods -l app.kubernetes.io/name={{ include "pihole.name" . }}
+   View services: kubectl get services -l app.kubernetes.io/name={{ include "pihole.name" . }}
+   View logs:     kubectl logs -l app.kubernetes.io/name={{ include "pihole.name" . }}

--- a/charts/pihole/templates/_helpers.tpl
+++ b/charts/pihole/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+App name
+*/}}
+{{- define "pihole.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Resources full name
+*/}}
+{{- define "pihole.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Commons Label for all resources
+*/}}
+{{- define "pihole.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "pihole.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector Labels for pods
+*/}}
+{{- define "pihole.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pihole.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Name for the service account
+*/}}
+{{- define "pihole.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pihole.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "pihole.secretName" -}}
+{{- if .Values.password.create -}}
+{{- printf "%s-secret" (include "pihole.fullname" .) -}}
+{{- else -}}
+{{- .Values.password.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "pihole.secretKey" -}}
+{{- if .Values.password.create -}}
+admin-password
+{{- else -}}
+{{- .Values.password.existingSecretKey -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pihole/templates/configmap-dnscrypt.yaml
+++ b/charts/pihole/templates/configmap-dnscrypt.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.sidecar.dnscrypt.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pihole.fullname" . }}-dnscrypt-config
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+data:
+  dnscrypt-proxy.toml: |
+    listen_addresses = ['127.0.0.1:{{ .Values.sidecar.dnscrypt.port }}']
+    max_clients = 250
+    
+    # DNS Servers
+    server_names = {{ .Values.sidecar.dnscrypt.config.server_names | toJson }}
+    
+    # Caching
+    cache = {{ .Values.sidecar.dnscrypt.config.cache }}
+    cache_size = {{ .Values.sidecar.dnscrypt.config.cache_size }}
+    cache_neg_min_ttl = 60
+    cache_neg_max_ttl = 600
+    
+    # Security
+    require_dnssec = false
+    require_nolog = true
+    require_nofilter = true
+    
+    # Performance
+    timeout = 5000
+    keepalive = 30
+    
+    # Sources
+    [sources]
+      [sources.'public-resolvers']
+      urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v3/public-resolvers.md']
+      cache_file = '/tmp/public-resolvers.md'
+      minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+      refresh_delay = 72
+{{- end }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -1,0 +1,96 @@
+# templates/deployment.yaml - Versión 1
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pihole.fullname" . }}
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "pihole.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pihole.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "pihole.serviceAccountName" . }}
+      containers:
+      - name: pihole
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        ports:
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 53
+          name: dns-udp
+          protocol: UDP
+        - containerPort: 80
+          name: web
+          protocol: TCP
+        env:
+        - name: TZ
+          value: {{ .Values.config.timezone | quote }}
+        - name: FTLCONF_webserver_api_password
+          valueFrom:
+            secretKeyRef: 
+              name: {{ include "pihole.secretName" . }}
+              key: {{ include "pihole.secretKey" . }}
+        - name: FTLCONF_dns_upstreams
+          value: {{ .Values.config.dnsUpstreams | quote }}
+
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        {{- end }}
+        
+        {{- if or .Values.persistence.config.enabled .Values.persistence.dnsmasq.enabled }}
+        volumeMounts:
+        {{- if .Values.persistence.config.enabled }}
+        - name: config
+          mountPath: /etc/pihole
+        {{- end }}
+        {{- if .Values.persistence.dnsmasq.enabled }}
+        - name: dnsmasq
+          mountPath: /etc/dnsmasq.d
+        {{- end }}
+        {{- end }}
+      
+       {{- if .Values.sidecar.dnscrypt.enabled }}
+      - name: dnscrypt-proxy
+        image: {{ .Values.sidecar.dnscrypt.image.repository }}:{{ .Values.sidecar.dnscrypt.image.tag }}
+        ports:
+        - containerPort: {{ .Values.sidecar.dnscrypt.port }}
+          name: dnscrypt
+        volumeMounts:
+        - name: dnscrypt-config
+          mountPath: /etc/dnscrypt-proxy
+        {{- if .Values.sidecar.dnscrypt.resources }}
+        resources:
+          {{- toYaml .Values.sidecar.dnscrypt.resources | nindent 10 }}
+        {{- end }}
+      {{- end }}
+
+      volumes:
+      {{- if .Values.persistence.config.enabled }}
+      - name: config
+        persistentVolumeClaim:
+          claimName: {{ include "pihole.fullname" . }}-config
+      {{- end }}
+      {{- if .Values.persistence.dnsmasq.enabled }}
+      - name: dnsmasq
+        persistentVolumeClaim:
+          claimName: {{ include "pihole.fullname" . }}-dnsmasq
+      {{- end }}
+      {{- if .Values.sidecar.dnscrypt.enabled }}
+      - name: dnscrypt-config
+        configMap:
+          name: {{ include "pihole.fullname" . }}-dnscrypt-config
+      {{- end }}
+
+
+      

--- a/charts/pihole/templates/ingress.yaml
+++ b/charts/pihole/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "pihole.fullname" . }}-web
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.ingress.host | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "pihole.fullname" . }}-web
+            port:
+              number: {{ .Values.services.web.port }}
+  {{- if .Values.ingress.tls.enabled}}
+  tls:
+  - hosts: 
+    - {{ .Values.ingress.host | quote }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+
+{{- end -}}

--- a/charts/pihole/templates/pvc.yaml
+++ b/charts/pihole/templates/pvc.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.persistence.config.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "pihole.fullname" . }}-config
+  {{- if .Values.persistence.config.annotations }}
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.persistence.config.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.config.accessModes }}
+    - {{ . }}
+    {{- end }}
+  {{- if .Values.persistence.config.storageClass }}
+  storageClassName: {{ .Values.persistence.config.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size }}
+  {{- if .Values.persistence.config.selector }}
+  selector:
+    {{- toYaml .Values.persistence.config.selector | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.persistence.dnsmasq.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "pihole.fullname" . }}-dnsmasq
+  {{- if .Values.persistence.dnsmasq.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.persistence.dnsmasq.annotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.dnsmasq.accessModes }}
+    - {{ . }}
+    {{- end }}
+  {{- if .Values.persistence.config.storageClass }}
+  storageClassName: {{ .Values.persistence.dnsmasq.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.dnsmasq.size }}
+  {{- if .Values.persistence.dnsmasq.selector }}
+  selector:
+    {{- toYaml .Values.persistence.dnsmasq.selector | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/pihole/templates/secret.yaml
+++ b/charts/pihole/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.password.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pihole.fullname" . }}-secret
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+type: Opaque
+data:
+  admin-password: {{ .Values.password.value | b64enc | quote }}
+{{- end }}

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -1,0 +1,23 @@
+
+{{- if .Values.services.dns.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pihole.fullname" . }}-dns
+spec:
+  type: {{ .Values.services.dns.type }}
+  {{- if and (eq .Values.services.dns.type "LoadBalancer") .Values.services.dns.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.services.dns.loadBalancerIP }}
+  {{- end}}
+  ports:
+  - name: dns-tcp
+    port: 53
+    targetPort: 53
+    protocol: TCP
+  - name: dns-udp
+    port: 53
+    targetPort: 53
+    protocol: UDP
+  selector:
+    {{- include "pihole.selectorLabels" . | nindent 4 }}
+{{- end}}

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pihole.fullname" . }}-web
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  selector:
+    {{- include "pihole.selectorLabels" . | nindent 4 }}

--- a/charts/pihole/templates/serviceaccount.yaml
+++ b/charts/pihole/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pihole.serviceAccountName" . }}
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -1,0 +1,92 @@
+image:
+  repository: pihole/pihole
+  tag: "2025.08.0"
+
+nameOverride: ""        
+fullnameOverride: ""
+commonLabels: {}
+podLabels: {}
+
+resources:  
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+password:
+  create: true
+  value: "changeme123"
+  existingSecret: ""
+  existingSecretKey: "admin-password"
+
+sidecar:
+  dnscrypt:
+    enabled: true                        
+    image: 
+      repository: klutchell/dnscrypt-proxy
+      tag: "latest"
+    port: 5053
+    config:
+      server_names: ['cloudflare', 'quad9']
+      listen_addresses: ['127.0.0.1:5053']
+      cache: true
+      cache_size: 4096
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
+config:
+  timezone: "Europe/Madrid"
+  dnsUpstreams: "127.0.0.1#5053"
+
+services:
+  dns:
+    enabled: true
+    type: LoadBalancer
+    loadBalancerIP: ""
+  
+  web:
+    enabled: true
+    type: ClusterIP
+    port: 80
+
+ingress:
+  enabled: true 
+  className: "traefik" 
+  host: "pihole.local" 
+  tls:
+    enabled: true
+    secretName: "pihole-tls"
+  annotations: {}
+
+persistence:
+  config:
+    enabled: true
+    storageClass: ""
+    size: "1Gi"
+    accessModes:
+      - ReadWriteOnce
+    selector: {}
+    annotations: {}
+  
+  dnsmasq:
+    enabled: true
+    storageClass: ""
+    size: "500Mi"
+    accessModes:
+      - ReadWriteOnce
+    selector: {}
+    annotations: {}
+  


### PR DESCRIPTION
## Summary
- Added complete Pi-hole Helm chart for network-wide DNS ad-blocking
- Integrated DNSCrypt-proxy sidecar for encrypted upstream DNS queries
- Created comprehensive documentation with installation examples
- Updated main README to showcase the new pihole chart

## Features
- Network-wide DNS ad-blocking with Pi-hole
- DNSCrypt-proxy sidecar for secure DNS queries
- Persistent storage for configuration and logs
- LoadBalancer service for DNS traffic
- Web interface with ingress and TLS support
- Comprehensive configuration options

## Test plan
- [x] Verify chart templates render correctly with `helm template`
- [x] Test basic installation with default values
- [x] Validate DNS service creates LoadBalancer
- [x] Confirm web interface accessible via ingress
- [x] Test DNSCrypt-proxy sidecar functionality
- [x] Verify persistent storage mounts correctly