### PR TITLE
fix: resolve gh-pages workflow conflicts and add testing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,14 +40,18 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Generate Pages README
-        run: |
-          ./generate-pages-readme.sh > README.md
-
       - name: Deploy to GitHub Pages
         run: |
-          git fetch origin gh-pages:gh-pages 2>/dev/null || true
-          git checkout gh-pages 2>/dev/null || git checkout --orphan gh-pages
+          git fetch origin gh-pages 2>/dev/null || true
+          if git show-ref --verify --quiet refs/heads/gh-pages; then
+            git checkout gh-pages
+            git reset --hard origin/gh-pages 2>/dev/null || git reset --hard HEAD
+          else
+            git checkout --orphan gh-pages
+          fi
+          ./generate-pages-readme.sh > README.md
           git add README.md
-          git commit -m "docs: update repository documentation" || exit 0
-          git push origin gh-pages --force
+          if ! git diff --staged --quiet; then
+            git commit -m "docs: update repository documentation"
+            git push origin gh-pages --force
+          fi

--- a/.github/workflows/test-pages.yaml
+++ b/.github/workflows/test-pages.yaml
@@ -1,0 +1,74 @@
+name: Test Pages Generation
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.14.0
+
+      - name: Test README Generation Script
+        run: |
+          chmod +x ./generate-pages-readme.sh
+          ./generate-pages-readme.sh > test-README.md
+          echo "Generated README preview:"
+          echo "========================="
+          head -20 test-README.md
+
+      - name: Test GitHub Pages Workflow Logic
+        run: |
+          echo "Testing gh-pages branch logic..."
+          
+          # Test branch existence check
+          if git show-ref --verify --quiet refs/heads/gh-pages; then
+            echo "✓ Branch gh-pages exists locally"
+            git checkout gh-pages
+          else
+            echo "✓ Branch gh-pages doesn't exist, would create orphan"
+            echo "✓ Simulating: git checkout --orphan gh-pages"
+          fi
+          
+          # Test README generation
+          echo "✓ Testing README generation..."
+          ./generate-pages-readme.sh > simulated-README.md
+          
+          # Test if there would be changes to commit
+          echo "✓ Testing if changes would be committed..."
+          if [ -f simulated-README.md ]; then
+            echo "✓ README generated successfully"
+            wc -l simulated-README.md
+          else
+            echo "❌ README generation failed"
+            exit 1
+          fi
+
+      - name: Validate Chart Syntax
+        run: |
+          for chart in charts/*/; do
+            if [ -d "$chart" ]; then
+              chart_name=$(basename "$chart")
+              echo "Validating $chart_name..."
+              helm lint "$chart"
+            fi
+          done

--- a/.github/workflows/test-pages.yaml
+++ b/.github/workflows/test-pages.yaml
@@ -63,12 +63,23 @@ jobs:
             exit 1
           fi
 
-      - name: Validate Chart Syntax
+      - name: Validate Charts
         run: |
           for chart in charts/*/; do
             if [ -d "$chart" ]; then
               chart_name=$(basename "$chart")
-              echo "Validating $chart_name..."
+              echo "🔍 Validating chart: $chart_name"
+              echo "================================"
+              
+              # Lint the chart
+              echo "📋 Running helm lint..."
               helm lint "$chart"
+              
+              # Template the chart to check rendering
+              echo "🔧 Testing helm template rendering..."
+              helm template test-release "$chart" --dry-run
+              
+              echo "✅ Chart $chart_name validated successfully"
+              echo ""
             fi
           done


### PR DESCRIPTION
## Summary
- Fix fatal error in gh-pages deployment workflow 
- Add comprehensive testing workflow for PRs
- Improve error handling and branch management

## Changes
### Release Workflow (release.yaml)
- Remove problematic `git fetch origin gh-pages:gh-pages` command
- Add proper branch existence checks
- Consolidate README generation within deployment step
- Improve error handling with fallback options

### New Testing Workflow (test-pages.yaml)
- Test README generation without actual deployment
- Validate chart syntax with helm lint
- Safe testing of gh-pages branch logic
- Preview generated README in workflow output
- Triggers on PRs and manual dispatch

## Test Plan
- [x] Test workflow runs without errors
- [x] README generation works correctly
- [x] Chart validation passes
- [x] No actual deployment occurs during testing

This allows us to validate changes safely before merging to main.