### PR TITLE
fix: add missing gh-pages branch creation step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,19 @@ jobs:
         with:
           version: v3.14.0
 
+      - name: Create gh-pages branch if needed
+        run: |
+          if ! git ls-remote --exit-code origin gh-pages >/dev/null 2>&1; then
+            echo "Creating gh-pages branch..."
+            git checkout --orphan gh-pages
+            git rm -rf .
+            echo "# Helm Charts Repository" > index.html
+            git add index.html
+            git commit -m "Initial gh-pages commit"
+            git push origin gh-pages
+            git checkout main
+          fi
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:


### PR DESCRIPTION
## Problem
The chart-releaser workflow is failing with:
```
fatal: invalid reference: origin/gh-pages
```

## Solution  
Add the missing step to create the gh-pages branch before running chart-releaser.

## Changes
- Add "Create gh-pages branch if needed" step before chart-releaser execution
- Check if gh-pages exists remotely before creating
- Create initial index.html to establish the branch
- Return to main branch after creation

This ensures chart-releaser can find the required pages branch reference.