### PR TITLE
fix: simplify chart-releaser to follow official Helm documentation

### DIFF
--- a/.cr.yaml
+++ b/.cr.yaml
@@ -3,4 +3,4 @@ owner: barbar0jav1er
 git-repo: homelab-charts
 pages-branch: gh-pages
 remote: origin
-charts-repo-url: https://charts.cubancodelab.net
+charts-repo-url: https://helms.cubancodelab.net


### PR DESCRIPTION
## Problem
The current workflow is overly complex with custom GitHub Pages logic that's causing errors and conflicts.

## Solution
Simplify to follow the official Helm chart-releaser documentation exactly:

## Changes
- **Simplified workflow**: Remove all custom logic, use standard chart-releaser-action@v1.7.0
- **Clean gh-pages branch**: Created manually with simple README.md as per documentation
- **Correct URL**: Update all references to `helms.cubancodelab.net`
- **No custom README generation**: Let chart-releaser handle everything automatically
- **Standard configuration**: Follow official Helm best practices

## What This Fixes
- ❌ `fatal: invalid reference: origin/gh-pages` errors
- ❌ Complex branch creation logic
- ❌ Conflicting README generation steps
- ❌ Over-engineered workflow

## Result
Clean, simple workflow that works exactly like the official Helm documentation shows.