### PR TITLE
fix: correct seerr image tag to v3.0.1

### DIFF
--- a/charts/seerr/Chart.yaml
+++ b/charts/seerr/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: seerr
 description: A Helm chart for Seerr - media request and discovery tool
 type: application
-version: 0.1.4
-appVersion: "3.0.1"
+version: 0.1.5
+appVersion: "v3.0.1"
 home: https://github.com/seerr-team/seerr
 sources:
   - https://github.com/seerr-team/seerr

--- a/charts/seerr/values.yaml
+++ b/charts/seerr/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/seerr-team/seerr
-  tag: "3.0.1"
+  tag: "v3.0.1"
   pullPolicy: IfNotPresent
 
 env:


### PR DESCRIPTION
The tag 3.0.1 was missing the v prefix.